### PR TITLE
Fixed incorrect php version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   ],
   "require": {
-    "php": "^8.1 || ^8.2",
+    "php": "^8.1",
     "nunomaduro/collision": "^7.5",
     "phpunit/phpunit": "^10.1"
   },


### PR DESCRIPTION
`^8.1` already allows all 8.x versions equal to or greater than 8.1.0.